### PR TITLE
Add minimal async tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pyserial==3.5
 pyserial-asyncio==0.6
 pytz==2025.2
 typing_extensions==4.13.2
+pytest==8.3.5
+pytest-asyncio==0.23.5

--- a/tests/test_inverter_battery_control.py
+++ b/tests/test_inverter_battery_control.py
@@ -1,0 +1,49 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import pytest
+
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from huawei_sun2000_control import inverter_battery_control as ibc
+
+@pytest.mark.asyncio
+async def test_ensure_and_set(monkeypatch):
+    register = SimpleNamespace(name="REG")
+    bridge = SimpleNamespace(slave_id=42)
+    bridge.ensure_logged_in = AsyncMock()
+    bridge.set = AsyncMock()
+    bridge.client = SimpleNamespace()
+    bridge.client.get = AsyncMock(return_value=SimpleNamespace(value=1))
+
+    await ibc.ensure_and_set(bridge, register, 1, "Label")
+
+    bridge.ensure_logged_in.assert_awaited_once()
+    bridge.set.assert_awaited_once_with(register, 1)
+    bridge.client.get.assert_awaited_once_with(register, slave=42)
+
+
+@pytest.mark.asyncio
+async def test_read_param_returns_value():
+    register = SimpleNamespace(name="REG")
+    bridge = SimpleNamespace(slave_id=1, client=SimpleNamespace())
+    bridge.client.get = AsyncMock(return_value=SimpleNamespace(value=5))
+
+    value = await ibc.read_param(bridge, register, "Label")
+    assert value == 5
+
+
+@pytest.mark.asyncio
+async def test_stop_charge_cancels_monitor_task(monkeypatch):
+    bridge = SimpleNamespace(slave_id=1)
+    bridge.client = SimpleNamespace()
+    bridge.client.get = AsyncMock(return_value=SimpleNamespace(value=0))
+    bridge._monitor_task = asyncio.create_task(asyncio.sleep(0.05))
+
+    ensure_mock = AsyncMock()
+    monkeypatch.setattr(ibc, "ensure_and_set", ensure_mock)
+
+    await ibc.stop_charge(bridge)
+
+    assert bridge._monitor_task.cancelled()
+    assert ensure_mock.await_count == 4

--- a/tests/test_inverter_telemetry.py
+++ b/tests/test_inverter_telemetry.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import pytest
+
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from huawei_sun2000_control import inverter_telemetry as it
+
+@pytest.mark.asyncio
+async def test_read_param_returns_value():
+    register = SimpleNamespace(name="REG")
+    bridge = SimpleNamespace(slave_id=1, client=SimpleNamespace())
+    bridge.client.get = AsyncMock(return_value=SimpleNamespace(value=7))
+
+    val = await it.read_param(bridge, register, "Label")
+    assert val == 7
+
+
+@pytest.mark.asyncio
+async def test_read_active_power_uses_read_param(monkeypatch):
+    bridge = object()
+    dummy_reg = object()
+    monkeypatch.setattr(it.rn, "INV_ACTIVE_POWER", dummy_reg, raising=False)
+    rp = AsyncMock(return_value=11)
+    monkeypatch.setattr(it, "read_param", rp)
+
+    result = await it.read_active_power(bridge)
+    rp.assert_awaited_once_with(bridge, dummy_reg, "Inverter Active Power (W)")
+    assert result == 11


### PR DESCRIPTION
## Summary
- create `tests/` with async pytest coverage
- add pytest requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842beb83c6883308ee39763faa9cf1d